### PR TITLE
Feature/search builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: ruby
+sudo: false
+services: mongodb
+cache: bundler
+notifications:
+  email: false
+env:
+  - RAILS_ENV=test
+  - CI=true
+global_env:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+rvm:
+  - 2.2.4
+script:
+  - bundle exec rake db:test:prepare
+  - bundle exec rake db:seed
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
   email: false
 env:
   - RAILS_ENV=test
-  - CI=true
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-rails'
   gem 'rspec-its'
+  gem 'rspec-collection_matchers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -239,6 +241,7 @@ DEPENDENCIES
   rdf-mongo
   rdf-turtle (~> 1.99)
   rspec
+  rspec-collection_matchers
   rspec-its
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,6 +63,7 @@ class CatalogController < ApplicationController
     # handler defaults, or have no facets.
     # Note: this is a generic method, not specific to Solr
     config.add_facet_fields_to_solr_request!
+    config.add_field_configuration_to_solr_request!
 
     # Sparql fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -102,16 +102,21 @@ class CatalogController < ApplicationController
     #
     # Adds a CONTAINS filter on the specified variable
     # * `field name` is predicate or other distinguishing identifier
-    # * `variable` is the SPARQL variable associated with the field
-    # * `patterns` (optinoal) are SPARQL triple patterns necessary to navigate between `?id` and `variable`.
+    # * `variable` is one or more SPARQL variables associated with the fields to search
+    # * `patterns` (optional) are SPARQL triple patterns necessary to filter for matching triples.
     # * `predicate` defaults to _field name_, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
-    # * `patterns` (optional) are SPARQL triple patterns necessary filter results based on the search term. Defaults to `"FILTER(CONTAINS(%{variable}, '%{term}'))"`, there `%{lab_term}` is substituted in the .
-    # * `filter_language` set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
-    config.add_search_field('skos:prefLabel') do |field|
+    # * `patterns` (optional) are SPARQL triple patterns necessary filter results based on the search term. Defaults to `"FILTER(CONTAINS(%{variable}, '%{term}'))"`, there `%{lab_term}` is substituted in the. where multiple variables are COALESCED
+    config.add_search_field('all_fields') do |field|
+      field.label = 'All Fields'
+      field.default = true
+      field.variable = %w(?lab ?defn ?num_lab)
+      field.patterns = ["FILTER(CONTAINS(COALESCE(?lab, ?defn, ?num_lab), '%{q}'))"]
+    end
+
+    config.add_search_field('label') do |field|
       field.label = 'Label'
       field.variable = "?lab"
       field.patterns = ["FILTER(CONTAINS(?lab, '%{q}'))"]
-      field.filter_language = true
     end
 
     # "sort results by" select (pulldown)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -42,11 +42,12 @@ class CatalogController < ApplicationController
     #config.per_page = [10,20,50,100]
 
     # Facet fields, may be bound when querying
-    # * field name is predicate or other distinguishing identifier
-    # * variable is the SPARQL variable associated with the field
-    # * patterns (optinal) are SPARQL triple patterns necessary to navigate between `?id` and variable.
-    # * predicate defaults to field name, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
-    # * filter_language set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
+    # * _field name_ is predicate or other distinguishing identifier
+    # * `label` used for human-readible form label
+    # * `variable` is the SPARQL variable associated with the field
+    # * `patterns` (optional) are SPARQL triple patterns necessary to navigate between `?id` and `variable`. Defaults to a pattern composed of `?id`, `predicate` and `variable`.
+    # * `predicate` defaults to _field name_, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
+    # * `filter_language` set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
     config.add_facet_field 'num_label',
       :label => 'Numismatics',
       :variable => "?num_lab",
@@ -54,15 +55,22 @@ class CatalogController < ApplicationController
         "?id dcterms:isPartOf ?num",
         "?num a nmo:FieldOfNumismatics",
         "?num skos:prefLabel ?num_lab"
-      ], :filter_language => true
+      ],
+      :filter_language => true
+
+    # Have BL send all facet field names to Sparql, which has been the default
+    # previously. Simply remove these lines if you'd rather use Sparql request
+    # handler defaults, or have no facets.
+    # Note: this is a generic method, not specific to Solr
+    config.add_facet_fields_to_solr_request!
 
     # Sparql fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display 
-    # * field name is predicate or other distinguishing identifier
-    # * variable is the SPARQL variable associated with the field
-    # * predicate defaults to field name, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
-    # * patterns (optinal) are SPARQL triple patterns necessary to navigate between `?id` and variable. They default to using the field name as the predicate relating `?id` and the variable. They default to using the field name as the predicate relating `?id` and the variable. These are also used in CONSTRUCT when generating RDF triples to frame
-    # * filter_language set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
+    # * _field name_ is predicate or other distinguishing identifier
+    # * `variable` is the SPARQL variable associated with the field
+    # * `predicate` defaults to field name, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
+    # * `patterns` (optional) are SPARQL triple patterns necessary to navigate between `?id` and `variable`. They default to using the _field name_ as the predicate relating `?id` and `variable`. These are also used in CONSTRUCT when generating RDF triples to frame.
+    # * `filter_language` set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
     config.add_index_field 'skos:prefLabel', :label => 'Label', :variable => "?lab", :filter_language => true
     config.add_index_field 'skos:definition', :label => 'Definition', :variable => "?defn", :filter_language => true
     config.add_index_field 'num_label',
@@ -72,9 +80,10 @@ class CatalogController < ApplicationController
         "?id dcterms:isPartOf ?num",
         "?num a nmo:FieldOfNumismatics",
         "?num skos:prefLabel ?num_lab"
-      ], :filter_language => true
+      ],
+      :filter_language => true
 
-    # solr fields to be displayed in the show (single result) view
+    # Sparql fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display 
     config.add_show_field 'skos:prefLabel', :label => 'Label', :variable => "?lab", :filter_language => true
     config.add_show_field 'skos:definition', :label => 'Definition', :variable => "?defn", :filter_language => true
@@ -85,74 +94,25 @@ class CatalogController < ApplicationController
         "?id dcterms:isPartOf ?num",
         "?num a nmo:FieldOfNumismatics",
         "?num skos:prefLabel ?num_lab"
-      ], :filter_language => true
+      ],
+      :filter_language => true
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
-    # Search fields will inherit the :qt solr request handler from
-    # config[:default_solr_parameters], OR can specify a different one
-    # with a :qt key/value. Below examples inherit, except for subject
-    # that specifies the same :qt as default for our own internal
-    # testing purposes.
-    #
-    # The :key is what will be used to identify this BL search field internally,
-    # as well as in URLs -- so changing it after deployment may break bookmarked
-    # urls.  A display label will be automatically calculated from the :key,
-    # or can be specified manually to be different. 
-
-    # This one uses all the defaults set by the solr request handler. Which
-    # solr request handler? The one set in config[:default_solr_parameters][:qt],
-    # since we aren't specifying it otherwise. 
-    
-    #config.add_search_field 'all_fields', :label => 'All Fields'
-
-    # Now we see how to over-ride Solr request handler defaults, in this
-    # case for a BL "search field", which is really a dismax aggregate
-    # of Solr search fields. 
-    
-    #config.add_search_field('title') do |field|
-    #  # solr_parameters hash are sent to Solr as ordinary url query params. 
-    #  field.solr_parameters = { :'spellcheck.dictionary' => 'title' }
-    #
-    #  # :solr_local_parameters will be sent using Solr LocalParams
-    #  # syntax, as eg {! qf=$title_qf }. This is neccesary to use
-    #  # Solr parameter de-referencing like $title_qf.
-    #  # See: http://wiki.apache.org/solr/LocalParams
-    #  field.solr_local_parameters = { 
-    #    :qf => '$title_qf',
-    #    :pf => '$title_pf'
-    #  }
-    #end
-
-    # Adds a MATCH filter on the specified variable
+    # Adds a CONTAINS filter on the specified variable
+    # * `field name` is predicate or other distinguishing identifier
+    # * `variable` is the SPARQL variable associated with the field
+    # * `patterns` (optinoal) are SPARQL triple patterns necessary to navigate between `?id` and `variable`.
+    # * `predicate` defaults to _field name_, but may be set separately if multiple fields use the same predicate (i.e., in different entities)
+    # * `patterns` (optional) are SPARQL triple patterns necessary filter results based on the search term. Defaults to `"FILTER(CONTAINS(%{variable}, '%{term}'))"`, there `%{lab_term}` is substituted in the .
+    # * `filter_language` set to true, if the configured language should be used as a filter for the variable result if it is a language-tagged literal.
     config.add_search_field('skos:prefLabel') do |field|
       field.label = 'Label'
       field.variable = "?lab"
-      field.filter = "FILTER(MATCH(?lab, '%{lab_term}'))"
-      field.term = :lab_term
+      field.patterns = ["FILTER(CONTAINS(?lab, '%{q}'))"]
       field.filter_language = true
     end
-    
-    #config.add_search_field('author') do |field|
-    #  field.solr_parameters = { :'spellcheck.dictionary' => 'author' }
-    #  field.solr_local_parameters = { 
-    #    :qf => '$author_qf',
-    #    :pf => '$author_pf'
-    #  }
-    #end
-    
-    # Specifying a :qt only to show it's possible, and so our internal automated
-    # tests can test it. In this case it's the same as 
-    # config[:default_solr_parameters][:qt], so isn't actually neccesary. 
-    #config.add_search_field('subject') do |field|
-    #  field.solr_parameters = { :'spellcheck.dictionary' => 'subject' }
-    #  field.qt = 'search'
-    #  field.solr_local_parameters = { 
-    #    :qf => '$subject_qf',
-    #    :pf => '$subject_pf'
-    #  }
-    #end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and

--- a/app/models/blacklight/sparql.rb
+++ b/app/models/blacklight/sparql.rb
@@ -1,6 +1,7 @@
 module Blacklight
   module Sparql
     autoload :Document, 'blacklight/sparql/document'
+    autoload :FacetPaginator, 'blacklight/sparql/facet_paginator'
     autoload :Repository, 'blacklight/sparql/repository'
     autoload :Request, 'blacklight/sparql/request'
     autoload :Response, 'blacklight/sparql/response'

--- a/app/models/blacklight/sparql/facet_paginator.rb
+++ b/app/models/blacklight/sparql/facet_paginator.rb
@@ -1,0 +1,26 @@
+module Blacklight::Sparql
+  # Pagination for facet values -- works by setting the limit to max
+  # displayable. You have to ask Sparql for limit+1, to get enough
+  # results to see if 'more' are available'. That is, the all_facet_values
+  # arg in constructor should be the result of asking solr for limit+1
+  # values. 
+  # This is a workaround for the fact that Sparql itself can't compute
+  # the total values for a given facet field,
+  # so we cannot know how many "pages" there are.
+  #
+  class FacetPaginator < Blacklight::FacetPaginator
+    # all_facet_values is a list of facet value objects returned by Sparql,
+    # asking Sparql for n+1 facet values.
+    # options:
+    # :limit =>  number to display per page, or (default) nil. Nil means
+    #            display all with no previous or next. 
+    # :offset => current item offset, default 0
+    # :sort => 'count' or 'index', solr tokens for facet value sorting, default 'count'. 
+    def initialize(all_facet_values, arguments = {})
+      super
+
+      # FIXME: facet sorting in SPARQL
+      @sort ||= :FIXME
+    end
+  end
+end

--- a/app/models/blacklight/sparql/facet_paginator.rb
+++ b/app/models/blacklight/sparql/facet_paginator.rb
@@ -19,8 +19,12 @@ module Blacklight::Sparql
     def initialize(all_facet_values, arguments = {})
       super
 
-      # FIXME: facet sorting in SPARQL
-      @sort ||= :FIXME
+      # Sort on facet value or count
+      @sort ||= if @limit.to_i > 0
+                  'count'
+                else
+                  'index'
+                end
     end
   end
 end

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -164,6 +164,8 @@ module Blacklight::Sparql
         # FIXME: ordering
         query += "ORDER BY #{facet[:variable]}\n"
 
+        # FIXME: consider facet prefixes for SPARQL
+
         facet_fields[name] = send_and_receive(query).map do |soln|
           [soln[var_sym].object, soln[:__count__].object]
         end.flatten

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -27,8 +27,8 @@ module Blacklight::Sparql
     # @param [Hash] params sparql query parameters
     # @option params [Hash{String => Array<String>}] :facet_values
     #   List of bound facets by variable, with individual or multiple values
-    # @option params [Hash{String => String}] :search
-    #   List of search terms by variable containing the substring
+    # @option params [Hash{String => Hash}] :search
+    #   Configuration for each search query. Based on the field definition with `:q` added for the value to search on.
     # @option params [Hash{String => Hash}] :facets
     #   Configuration for each facet aggregation query including sorting, offset/limit, and facet value prefix
     # @option params [Hash] :fields
@@ -74,7 +74,10 @@ module Blacklight::Sparql
       # FIXME escape filter values
       # FIXME non-string values?
       params.fetch(:search, {}).each do |variable, value|
-        where += "  FILTER(CONTAINS(#{variable}, '#{value}'))\n"
+        patterns = value.fetch(:patterns, ["FILTER(CONTAINS(%{variable}, '%{q}'))"])
+        patterns.each do |pattern|
+          where += pattern % value
+        end
       end
 
       # Add facet values

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -170,9 +170,10 @@ module Blacklight::Sparql
 
         # FIXME: consider facet prefixes for SPARQL
 
-        facet_fields[name] = send_and_receive(query).map do |soln|
-          [soln[var_sym].object, soln[:__count__].object]
-        end.flatten
+        # Facet field values as Hash
+        facet_fields[name] = send_and_receive(query).inject({}) do |memo, soln|
+          memo.merge(soln[var_sym].object => soln[:__count__].object)
+        end
       end
 
       facet_counts = HashWithIndifferentAccess.new
@@ -184,7 +185,7 @@ module Blacklight::Sparql
         numFound: count,
         document_model: blacklight_config.document_model,
         blacklight_config: blacklight_config
-      }
+      }.with_indifferent_access
       blacklight_config.response_model.new(docs, params, response_opts)
     end
 

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -161,8 +161,12 @@ module Blacklight::Sparql
         query += "OFFSET #{facet[:offset].to_i}\n" if facet[:offset]
         query += "LIMIT #{facet[:limit].to_i}\n" if facet[:limit]
 
-        # FIXME: ordering
-        query += "ORDER BY #{facet[:variable]}\n"
+        # Order by variable our count
+        query += if facet[:sort] == 'count'
+          "ORDER BY __count__\n"
+        else
+          "ORDER BY #{facet[:variable]}\n"
+        end
 
         # FIXME: consider facet prefixes for SPARQL
 

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -153,7 +153,8 @@ module Blacklight::Sparql
 
       # Get facet fields
       facet_fields = HashWithIndifferentAccess.new
-      params.fetch(:facets, {}).each do |name, facet|
+      params[:facets] ||= HashWithIndifferentAccess.new
+      params[:facets].each do |name, facet|
         var_sym = facet[:variable].to_s[1..-1].to_sym
         query = prefixes + "\nSELECT #{facet[:variable]} (COUNT(*) as ?__count__)" +
           where + "}\n" +

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -174,7 +174,8 @@ module Blacklight::Sparql
 
         # Facet field values as Hash
         facet_fields[name] = send_and_receive(query).inject({}) do |memo, soln|
-          memo.merge(soln[var_sym].object => soln[:__count__].object)
+          memo[soln[var_sym].object] = soln[:__count__].object if soln[var_sym]
+          memo
         end
       end
 

--- a/app/models/blacklight/sparql/request.rb
+++ b/app/models/blacklight/sparql/request.rb
@@ -1,4 +1,4 @@
-module Blacklight::Solr
+module Blacklight::Sparql
   class Request < HashWithIndifferentAccess
   end
 end

--- a/app/models/blacklight/sparql/response.rb
+++ b/app/models/blacklight/sparql/response.rb
@@ -20,30 +20,27 @@ module Blacklight::Sparql
     #  }
     #}
 
-    # FIXME: to get numFound requires two queries, one with a COUNT, and another with OFFSET/LIMIT
-    # FIXME: facets don't come naturally in response, they should be provided from the repository or document model based on a one-time query. This may require one select per facet to get back the distinct values; not sure if the facet values should be reduced by the query results, though.
-
     # Using required_dependency to work around Rails autoloading
     # problems when developing blacklight. Without this, any change
     # to this class breaks other classes in this namespace
-    #require_dependency 'blacklight/sparql/response/pagination_methods'
+    require_dependency 'blacklight/sparql/response/pagination_methods'
     #require_dependency 'blacklight/sparql/response/spelling'
-    #require_dependency 'blacklight/sparql/response/facets'
+    require_dependency 'blacklight/sparql/response/facets'
     #require_dependency 'blacklight/sparql/response/more_like_this'
     #require_dependency 'blacklight/sparql/response/group_response'
     require_dependency 'blacklight/sparql/response/response'
     require_dependency 'blacklight/sparql/response/group'
 
     include Response
-    #include PaginationMethods
+    include PaginationMethods
     #include Spelling
-    #include Facets
+    include Facets
     #include MoreLikeThis
 
     attr_reader :request_params
     attr_accessor :document_model, :blacklight_config
 
-    # @param [Array] docs
+    # @param [Array<Hash>] docs as expanded JSON-LD objects
     # @param [Hash{Symbol => Object}] request_params
     # @param [Hash{Symbol => Object}] options
     # @option options [Integer] :numFound
@@ -79,6 +76,10 @@ module Blacklight::Sparql
       @documents ||= (response['docs'] || []).collect{|doc| document_model.new(doc, self) }
     end
     alias_method :docs, :documents
+
+    def export_formats
+      documents.map { |x| x.export_formats.keys }.flatten.uniq
+    end
 
     def method_missing(meth, *args)
       $stderr.puts("Call to Response##{meth}")

--- a/app/models/blacklight/sparql/response.rb
+++ b/app/models/blacklight/sparql/response.rb
@@ -77,6 +77,11 @@ module Blacklight::Sparql
     end
     alias_method :docs, :documents
 
+    # FIXME: No grouping in SPARQL?
+    def grouped?
+      self.has_key? "grouped" # Always false
+    end
+
     def export_formats
       documents.map { |x| x.export_formats.keys }.flatten.uniq
     end

--- a/app/models/blacklight/sparql/response.rb
+++ b/app/models/blacklight/sparql/response.rb
@@ -24,7 +24,7 @@ module Blacklight::Sparql
     # problems when developing blacklight. Without this, any change
     # to this class breaks other classes in this namespace
     require_dependency 'blacklight/sparql/response/pagination_methods'
-    #require_dependency 'blacklight/sparql/response/spelling'
+    require_dependency 'blacklight/sparql/response/spelling'
     require_dependency 'blacklight/sparql/response/facets'
     #require_dependency 'blacklight/sparql/response/more_like_this'
     #require_dependency 'blacklight/sparql/response/group_response'
@@ -33,7 +33,7 @@ module Blacklight::Sparql
 
     include Response
     include PaginationMethods
-    #include Spelling
+    include Spelling
     include Facets
     #include MoreLikeThis
 

--- a/app/models/blacklight/sparql/response/facets.rb
+++ b/app/models/blacklight/sparql/response/facets.rb
@@ -1,0 +1,141 @@
+require 'ostruct'
+
+module Blacklight::Sparql::Response::Facets
+  # represents a facet value; which is a field value and its hit count
+  class FacetItem < OpenStruct
+    def initialize *args
+      options = args.extract_options!
+
+      # Backwards-compat method signature
+      value = args.shift
+      hits = args.shift
+
+      options[:value] = value if value
+      options[:hits] = hits if hits
+
+      super(options)
+    end
+
+    def label
+      super || value
+    end
+
+    def as_json(props = nil)
+      table.as_json(props)
+    end
+  end
+
+  # represents a facet; which is a field and its values
+  class FacetField
+    attr_reader :name, :items
+    def initialize name, items, options = {}
+      @name = name
+      @items = items
+      @options = options
+    end
+
+    def limit
+      @options[:limit] || sparql_default_limit
+    end
+
+    def sort
+      @options[:sort] || sparql_default_sort
+    end
+
+    def offset
+      @options[:offset] || sparql_default_offset
+    end
+
+    def prefix
+      @options[:prefix] || sparql_default_prefix
+    end
+
+    def index?
+      sort == 'index'
+    end
+
+    def count?
+      sort == 'count'
+    end
+
+    private
+    def sparql_default_limit
+      100
+    end
+
+    def sparql_default_sort
+      if limit > 0
+        'count'
+      else
+        'index'
+      end
+    end
+
+    def sparql_default_offset
+      0
+    end
+
+    def sparql_default_prefix
+      nil
+    end
+  end
+
+  ##
+  # Get all the Sparql facet data (fields right now) as a hash
+  def aggregations
+    @aggregations ||= {}.merge(facet_field_aggregations)
+  end
+
+  def facet_counts
+    @facet_counts ||= self['facet_counts'] || {}
+  end
+
+  # Returns the hash of all the facet_fields (ie: {'instock_b' => ['true', 123, 'false', 20]}
+  def facet_fields
+    @facet_fields ||= begin
+      facet_counts['facet_fields'] || {}
+    end
+  end
+
+  private
+  ##
+  # Convert facet_field response into
+  # a hash of FacetField objects
+  def facet_field_aggregations
+    facet_fields.each_with_object({}) do |(facet_field_name, values), hash|
+      items = values.map do |value, hits|
+        FacetItem.new(value: value, hits: hits)
+      end
+
+      options = facet_field_aggregation_options(facet_field_name)
+      hash[facet_field_name] = FacetField.new(facet_field_name,
+                                              items,
+                                              options)
+
+      if blacklight_config and !blacklight_config.facet_fields[facet_field_name]
+        # alias all the possible blacklight config names..
+        blacklight_config.facet_fields.select { |k,v| v.field == facet_field_name }.each do |key,_|
+          hash[key] = hash[facet_field_name]
+        end
+      end
+    end
+  end
+
+  def facet_field_aggregation_options(facet_field_name)
+    options = {}
+    facet_info = params[:facets].fetch(facet_field_name, {})
+    options[:sort] = facet_info[:sort] || params[:'facet.sort']
+    if facet_info[:limit] || params[:"facet.limit"]
+      options[:limit] = (facet_info[:limit] || params[:"facet.limit"]).to_i
+    end
+
+    if facet_info[:offset] || params[:"facet.offset"]
+      options[:offset] = (facet_info[:offset] || params[:"facet.offset"]).to_i
+    end
+
+    if facet_info[:prefix] || params[:"facet.prefix"]
+      options[:prefix] = (facet_info[:prefix] || params[:"facet.prefix"])
+    end
+    options
+  end
+end # end Facets

--- a/app/models/blacklight/sparql/response/pagination_methods.rb
+++ b/app/models/blacklight/sparql/response/pagination_methods.rb
@@ -1,0 +1,17 @@
+module Blacklight::Sparql::Response::PaginationMethods
+
+  include Kaminari::PageScopeMethods
+  include Kaminari::ConfigurationMethods::ClassMethods
+
+  def limit_value #:nodoc:
+    rows
+  end
+
+  def offset_value #:nodoc:
+    start
+  end
+
+  def total_count #:nodoc:
+    total
+  end
+end

--- a/app/models/blacklight/sparql/response/spelling.rb
+++ b/app/models/blacklight/sparql/response/spelling.rb
@@ -1,0 +1,28 @@
+# A mixin for making access to the spellcheck component data easy.
+#
+# Sparql does not provide any spelling hints
+#
+# response.spelling.words
+#
+module Blacklight::Sparql::Response::Spelling
+
+  def spelling
+    @spelling ||= Base.new(self)
+  end
+
+  class Base
+
+    attr :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    # No spelling suggestions
+    def words
+      []
+    end
+
+  end
+
+end

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -83,7 +83,10 @@ module Blacklight::Sparql
 
     def add_sparql_fields_to_query sparql_parameters
       fields = blacklight_config.show_fields.select(&method(:should_add_field_to_request?)).values
-      fields = blacklight_config.index_fields.select(&method(:should_add_field_to_request?)).values
+
+      blacklight_config.index_fields.select(&method(:should_add_field_to_request?)).values.each do |field|
+        fields << field unless field.any? {|f| f.variable == field.variable} # no duplicates
+      end
       sparql_parameters[:fields] = fields
     end
 

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -65,7 +65,7 @@ module Blacklight::Sparql
     # Add appropriate SPARQL facetting filters.
     def add_facetting_to_sparql sparql_parameters
       facet_fields_to_include_in_request.each do |field_name, facet|
-        sparql_parameters[:facet] ||= {}
+        sparql_parameters[:facets] ||= {}
         facet_param = {variable: facet.variable}
 
         facet_param[:sort] = facet.sort if facet.sort
@@ -77,7 +77,7 @@ module Blacklight::Sparql
 
         # FIXME: no support for Facet queries just yet
         #sparql_parameters.append_facet_query facet.query.map { |k, x| x[:fq] }
-        sparql_parameters[:facet][facet.variable] = facet_param
+        sparql_parameters[:facets][facet.variable] = facet_param
       end
     end
 
@@ -119,7 +119,7 @@ module Blacklight::Sparql
       facet_config = blacklight_config.facet_fields[facet]
 
       # Now override with our specific things for fetching facet values
-      sparql_parameters[:facet] ||= {}
+      sparql_parameters[:facets] ||= {}
       facet_param = {variable: facet_config.variable}
 
       limit = if scope.respond_to?(:facet_list_limit)
@@ -143,7 +143,7 @@ module Blacklight::Sparql
       facet_param[:sort]   = sort if blacklight_params[request_keys[:sort]]
       facet_param[:prefix] = prefix if blacklight_params[request_keys[:prefix]]
 
-      sparql_parameters[:facet][facet_config.variable] = facet_param
+      sparql_parameters[:facets][facet_config.variable] = facet_param
       sparql_parameters[:rows] = 0
     end
 

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -126,7 +126,8 @@ module Blacklight::Sparql
       facet_config = blacklight_config.facet_fields[facet]
 
       # Now override with our specific things for fetching facet values
-      sparql_parameters[:"facet.field"] = facet
+      sparql_parameters[:facet] ||= {}
+      facet_param = {variable: facet_config.variable}
 
       limit = if scope.respond_to?(:facet_list_limit)
                 scope.facet_list_limit.to_s.to_i
@@ -144,14 +145,16 @@ module Blacklight::Sparql
 
       # Need to set as f.facet_field.facet.*  to make sure we
       # override any field-specific default in the solr request handler.
-      sparql_parameters[:"f.#{facet}.facet.limit"] = limit + 1
-      sparql_parameters[:"f.#{facet}.facet.offset"] = offset
+      facet_param[:limit] = limit
+      facet_param[:offset] = offset
       if blacklight_params[request_keys[:sort]]
-        sparql_parameters[:"f.#{facet}.facet.sort"] = sort
+        facet_param[:sort] = sort
       end
+
       if blacklight_params[request_keys[:prefix]]
-        sparql_parameters[:"f.#{facet}.facet.prefix"] = prefix
+        facet_param[:prefix] = prefix
       end
+      sparql_parameters[:facet][facet_config.variable] = facet_param
       sparql_parameters[:rows] = 0
     end
 

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -4,7 +4,7 @@ module Blacklight::Sparql
 
     included do
       self.default_processor_chain = [
-        :add_query_to_sparql,
+        :add_query_to_sparql, :add_facet_fq_to_sparql,
         :add_facetting_to_sparql, :add_sparql_fields_to_query, :add_paging_to_sparql,
         :add_sorting_to_sparql, :add_group_config_to_sparql,
         :add_facet_paging_to_sparql
@@ -14,23 +14,50 @@ module Blacklight::Sparql
     ##
     # Take the user-entered query, and put it in the SPARQL params,
     # including config's "search field" params for current search field.
-    # also include setting spellcheck.q.
-    def add_query_to_sparql(sparql_parameters)
-      ###
-      # Merge in search field configured values, if present, over-writing general defaults
-
+    def add_query_to_sparql sparql_parameters
       if search_field
-        sparql_parameters.merge!(search_field.sparql_parameters) if search_field.sparql_parameters
+        search_def = {
+          variable: search_field.variable,
+          patterns: search_field.patterns
+        }
+
+        if blacklight_params[:q].is_a? Hash
+          q = blacklight_params[:q]
+          raise "FIXME, translation of Solr search for SPARQL"
+        elsif blacklight_params[:q]
+          # Create search field with variable, pattern and :q
+          search_def.merge!(q: blacklight_params[:q])
+          sparql_parameters[:search] = {search_def[:variable] => search_def}
+        end
+      end
+    end
+
+    ##
+    # Add any existing facet limits, stored in app-level HTTP query
+    # to Sparql
+    def add_facet_fq_to_sparql sparql_parameters
+
+      # convert a String value into an Array
+      if sparql_parameters[:fq].is_a? String
+        sparql_parameters[:fq] = [sparql_parameters[:fq]]
       end
 
-      ##
-      # Create XXX 'q' including the user-entered q
-      ##
-      if blacklight_params[:q].is_a? Hash
-        q = blacklight_params[:q]
-        raise "FIXME, translation of Solr search for SPARQL"
-      elsif blacklight_params[:q]
-        sparql_parameters[:q] = blacklight_params[:q]
+      # :fq, map from :f.
+      if ( blacklight_params[:f])
+        f_request_params = blacklight_params[:f]
+
+        f_request_params.each_pair do |facet_field, value_list|
+          next unless facet = blacklight_config.facet_fields[facet_field.to_s]
+          sparql_parameters[:facet_values] ||= {}
+          case Array(value_list).length
+          when 0
+          when 1
+            v = Array(value_list).first
+            sparql_parameters[:facet_values][facet.variable] = v unless v.to_s.empty?
+          else
+            sparql_parameters[:facet_values][facet.variable] = value_list
+          end
+        end
       end
     end
 
@@ -38,26 +65,26 @@ module Blacklight::Sparql
     # Add appropriate SPARQL facetting filters.
     def add_facetting_to_sparql sparql_parameters
       facet_fields_to_include_in_request.each do |field_name, facet|
-        sparql_parameters[:facet] ||= true
+        sparql_parameters[:facet] ||= {}
+        facet_param = {variable: facet.variable}
 
         case
-          when facet.pivot
-            raise "FIXME: SPARQL pivot?"
-            #sparql_parameters.append_facet_pivot facet.pivot.join(",")
           when facet.query
+            # FIXME: no support for Facet queries just yet
             sparql_parameters.append_facet_query facet.query.map { |k, x| x[:fq] }
           else
-            sparql_parameters.append_facet_fields facet.field
+            sparql_parameters[:facet][facet.variable] = facet_param
         end
 
-        if facet.sort
-          sparql_parameters[:sort] = facet.sort
-        end
+        # FIXME: can only sort on variable, may specify ASC or DESC
+        #if facet.sort
+        #  sparql_parameters[:sort] = facet.sort
+        #end
 
         # Support facet paging and 'more'
         # links, by sending a facet.limit one more than what we
         # want to page at, according to configured facet limits.
-        sparql_parameters[:limit] = (facet_limit_for(field_name) + 1) if facet_limit_for(field_name)
+        facet_param[:limit] = (facet_limit_for(field_name) + 1) if facet_limit_for(field_name)
       end
     end
 
@@ -126,9 +153,24 @@ module Blacklight::Sparql
       sparql_parameters[:rows] = 0
     end
 
+    # Look up facet limit for given facet_field. Will look at config, and
+    # if config is 'true' will look up from Solr @response if available. If
+    # no limit is avaialble, returns nil. Used from #add_facetting_to_solr
+    # to supply f.fieldname.facet.limit values in solr request (no @response
+    # available), and used in display (with @response available) to create
+    # a facet paginator with the right limit.
+    def facet_limit_for(facet_field)
+      facet = blacklight_config.facet_fields[facet_field]
+      return if facet.blank?
+
+      if facet.limit
+        facet.limit == true ? blacklight_config.default_facet_limit : facet.limit
+      end
+    end
+
     def facet_fields_to_include_in_request
       blacklight_config.facet_fields.select do |field_name,facet|
-        facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_sparql_request)
+        facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request)
       end
     end
 

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -82,12 +82,12 @@ module Blacklight::Sparql
     end
 
     def add_sparql_fields_to_query sparql_parameters
-      fields = blacklight_config.show_fields.select(&method(:should_add_field_to_request?)).values
+      fields = blacklight_config.show_fields.select(&method(:should_add_field_to_request?))
 
-      blacklight_config.index_fields.select(&method(:should_add_field_to_request?)).values.each do |field|
-        fields << field unless field.any? {|f| f.variable == field.variable} # no duplicates
+      blacklight_config.index_fields.select(&method(:should_add_field_to_request?)).each do |key, field|
+        fields[key] || field
       end
-      sparql_parameters[:fields] = fields
+      sparql_parameters[:fields] = fields.values
     end
 
     ###

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -68,23 +68,16 @@ module Blacklight::Sparql
         sparql_parameters[:facet] ||= {}
         facet_param = {variable: facet.variable}
 
-        case
-          when facet.query
-            # FIXME: no support for Facet queries just yet
-            sparql_parameters.append_facet_query facet.query.map { |k, x| x[:fq] }
-          else
-            sparql_parameters[:facet][facet.variable] = facet_param
-        end
-
-        # FIXME: can only sort on variable, may specify ASC or DESC
-        #if facet.sort
-        #  sparql_parameters[:sort] = facet.sort
-        #end
+        facet_param[:sort] = facet.sort if facet.sort
 
         # Support facet paging and 'more'
         # links, by sending a facet.limit one more than what we
         # want to page at, according to configured facet limits.
         facet_param[:limit] = (facet_limit_for(field_name) + 1) if facet_limit_for(field_name)
+
+        # FIXME: no support for Facet queries just yet
+        #sparql_parameters.append_facet_query facet.query.map { |k, x| x[:fq] }
+        sparql_parameters[:facet][facet.variable] = facet_param
       end
     end
 
@@ -145,15 +138,11 @@ module Blacklight::Sparql
 
       # Need to set as f.facet_field.facet.*  to make sure we
       # override any field-specific default in the solr request handler.
-      facet_param[:limit] = limit
+      facet_param[:limit]  = limit
       facet_param[:offset] = offset
-      if blacklight_params[request_keys[:sort]]
-        facet_param[:sort] = sort
-      end
+      facet_param[:sort]   = sort if blacklight_params[request_keys[:sort]]
+      facet_param[:prefix] = prefix if blacklight_params[request_keys[:prefix]]
 
-      if blacklight_params[request_keys[:prefix]]
-        facet_param[:prefix] = prefix
-      end
       sparql_parameters[:facet][facet_config.variable] = facet_param
       sparql_parameters[:rows] = 0
     end

--- a/spec/models/blacklight/sparql/repository_spec.rb
+++ b/spec/models/blacklight/sparql/repository_spec.rb
@@ -153,10 +153,10 @@ describe Blacklight::Sparql::Repository do
       it "should have expected facets" do
         expect(response[:facet_counts]).to eq({
           "facet_fields" => {
-            "num_label" => [
-              "Greek Numismatics", 12,
-              "Roman Numismatics", 2
-            ]
+            "num_label" => {
+              "Greek Numismatics" => 12,
+              "Roman Numismatics" => 2
+            }
           }
         })
       end

--- a/spec/models/blacklight/sparql/repository_spec.rb
+++ b/spec/models/blacklight/sparql/repository_spec.rb
@@ -49,10 +49,17 @@ describe Blacklight::Sparql::Repository do
     end
 
     it "should search variable" do
-      search_params = HashWithIndifferentAccess.new
-      search_params[:search] = {"?lit" => "foo"}
+      search_params = {search: {variable: "?lit", q: "foo"}}.with_indifferent_access
       allow(subject.connection).to receive(:query).and_return(mock_response)
       expect(subject.connection).to receive(:query).with(/FILTER\(CONTAINS\(\?lit, 'foo'\)\)/)
+
+      subject.search(search_params)
+    end
+
+    it "should search multiple variables" do
+      search_params = {search: {variable: %w(?a ?b), q: "foo"}}.with_indifferent_access
+      allow(subject.connection).to receive(:query).and_return(mock_response)
+      expect(subject.connection).to receive(:query).with(/FILTER\(CONTAINS\(COALESCE\(\?a,\?b\), 'foo'\)\)/)
 
       subject.search(search_params)
     end

--- a/spec/models/blacklight/sparql/response/facets_spec.rb
+++ b/spec/models/blacklight/sparql/response/facets_spec.rb
@@ -1,0 +1,215 @@
+require 'rails_helper'
+
+describe Blacklight::Sparql::Response::Facets do
+  describe Blacklight::Sparql::Response::Facets::FacetField do
+
+    describe "A field with default options" do
+      subject { described_class.new "my_field", [] }
+
+      its(:name) { should eq "my_field" }
+      its(:limit) { should eq 100 }
+      its(:sort) { should eq 'count' }
+      its(:offset) { should eq 0 }
+    end
+
+    describe "A field with additional options" do
+      subject { described_class.new "my_field", [], limit: 15, sort: 'alpha', offset: 23 }
+
+      its(:name) { should eq "my_field" }
+      its(:limit) { should eq 15 }
+      its(:sort) { should eq 'alpha' }
+      its(:offset) { should eq 23 }
+    end
+  end
+
+  describe "#aggregations" do
+    let(:facet_field) { {"my_field" => {}} }
+    let(:request_params) { {facets: {'my_field' => {}}} }
+    subject { Blacklight::Sparql::Response.new([], request_params, facet_counts: { facet_fields: facet_field }.with_indifferent_access)  }
+
+    describe "#limit" do
+      it "should extract a field-specific limit value" do
+        request_params[:facets]['my_field'][:limit] = 10
+        request_params['facet.limit'] = "15"
+        expect(subject.aggregations['my_field'].limit).to eq 10
+      end
+
+      it "should extract a global limit value" do
+        request_params['facet.limit'] = "15"
+        expect(subject.aggregations['my_field'].limit).to eq 15
+      end
+
+      it "should be the Sparql default limit if no value is found" do
+        expect(subject.aggregations['my_field'].limit).to eq 100
+      end
+    end
+
+    describe "#offset" do
+      it "should extract a field-specific offset value" do
+        request_params[:facets]['my_field'][:offset] = 10
+        request_params['facet.offset'] = "15"
+        expect(subject.aggregations['my_field'].offset).to eq 10
+      end
+
+      it "should extract a global offset value" do
+        request_params['facet.offset'] = "15"
+        expect(subject.aggregations['my_field'].offset).to eq 15
+      end
+
+      it "should be nil if no value is found" do
+        expect(subject.aggregations['my_field'].offset).to eq 0
+      end
+    end
+
+    describe "#sort" do
+      it "should extract a field-specific sort value" do
+        request_params[:facets]['my_field'][:sort] = "alpha"
+        request_params['facet.sort'] = "index"
+        expect(subject.aggregations['my_field'].sort).to eq 'alpha'
+      end
+
+      it "should extract a global sort value" do
+        request_params['facet.sort'] = "alpha"
+        expect(subject.aggregations['my_field'].sort).to eq 'alpha'
+      end
+
+      it "should default to count if no value is found and the default limit is used" do
+        expect(subject.aggregations['my_field'].sort).to eq 'count'
+        expect(subject.aggregations['my_field'].count?).to eq true
+      end
+      
+      it "should default to index if no value is found and the limit is unlimited" do
+        request_params['facet.limit'] = -1
+        expect(subject.aggregations['my_field'].sort).to eq 'index'
+        expect(subject.aggregations['my_field'].index?).to eq true
+      end
+    end
+
+    describe '#prefix' do
+      it 'extracts field-specific prefix values' do
+        request_params[:facets]['my_field'][:prefix] = "a"
+        request_params['facet.prefix'] = "b"
+        expect(subject.aggregations['my_field'].prefix).to eq 'a'
+      end
+
+      it "extracts a global sort value" do
+        request_params['facet.prefix'] = "abc"
+        expect(subject.aggregations['my_field'].prefix).to eq 'abc'
+      end
+
+      it "defaults to no prefix value" do
+        expect(subject.aggregations['my_field'].prefix).to be_nil
+      end
+    end
+  end
+
+  context "facet.missing", skip: "Not for SPARQL" do
+    let(:request_params) { {facets: {'some_field' => {}}} }
+    let(:response) do
+      {
+        facet_counts: {
+          facet_fields: {
+            some_field: {'a' => 1, nil => 2}
+          }
+        }
+      }
+    end
+    
+    subject { Blacklight::Sparql::Response.new([], request_params, response) }
+
+    it "should mark the facet.missing field with a human-readable label and fq" do
+      missing = subject.aggregations["some_field"].items.find { |i| i.value.nil? }
+
+      expect(missing.label).to eq "[Missing]"
+      expect(missing.fq).to eq "-some_field:[* TO *]"
+    end
+  end
+
+  describe "query facets", skip: "Not for SPARQL" do
+    let(:facet_config) { 
+      double(
+        key: 'my_query_facet_field',
+        :query => {
+           'a_simple_query' => { :fq => 'field:search', :label => 'A Human Readable label'},
+           'another_query' => { :fq => 'field:different_search', :label => 'Label'},
+           'without_results' => { :fq => 'field:without_results', :label => 'No results for this facet'}
+           }
+      )
+    }
+
+    let(:blacklight_config) { double(facet_fields: { 'my_query_facet_field' => facet_config } )}
+
+    let(:response) do
+      { 
+        facet_counts: {
+          facet_queries: {
+            'field:search' => 10,
+            'field:different_search' => 2,
+            'field:not_appearing_in_the_config' => 50,
+            'field:without_results' => 0
+          }
+        }
+      }
+    end
+
+    subject { Blacklight::Solr::Response.new(response, {}, blacklight_config: blacklight_config) }
+
+    it"should convert the query facets into a double RSolr FacetField" do
+      field = subject.aggregations['my_query_facet_field']
+
+      expect(field).to be_a_kind_of described_class
+
+      expect(field.name).to eq'my_query_facet_field'
+      expect(field.items.size).to eq 2
+      expect(field.items.map { |x| x.value }).to_not include 'field:not_appearing_in_the_config'
+
+      facet_item = field.items.find { |x| x.value == 'a_simple_query' }
+
+      expect(facet_item.value).to eq 'a_simple_query'
+      expect(facet_item.hits).to eq 10
+      expect(facet_item.label).to eq 'A Human Readable label'
+    end
+  end
+
+  describe "pivot facets", skip: "Not for SPARQL" do
+    let(:facet_config) {
+      double(key: 'my_pivot_facet_field', query: nil, pivot: ['field_a', 'field_b'])
+    }
+    
+    let(:blacklight_config) { double(facet_fields: { 'my_pivot_facet_field' => facet_config } )}
+
+    let(:response) do
+      { 
+        facet_counts: {
+          facet_pivot: { 
+            'field_a,field_b' => [
+              {
+                field: 'field_a', 
+                value: 'a', 
+                count: 10, 
+                pivot: [{field: 'field_b', value: 'b', count: 2}]
+              }]
+          }
+        }
+      }
+    end
+
+    subject { Blacklight::Solr::Response.new(response, {}, blacklight_config: blacklight_config) }
+
+    it "should convert the pivot facet into a double RSolr FacetField" do
+      field = subject.aggregations['my_pivot_facet_field']
+
+      expect(field).to be_a_kind_of described_class
+
+      expect(field.name).to eq 'my_pivot_facet_field'
+
+      expect(field.items.size).to eq 1
+
+      expect(field.items.first).to respond_to(:items)
+
+      expect(field.items.first.items.size).to eq 1
+      expect(field.items.first.items.first.fq).to eq({ 'field_a' => 'a' })
+    end
+  end
+
+end

--- a/spec/models/blacklight/sparql/response_spec.rb
+++ b/spec/models/blacklight/sparql/response_spec.rb
@@ -16,7 +16,7 @@ describe Blacklight::Sparql::Response do
 
   it 'should create a valid response class' do
     expect(r.docs).to have(11).docs
-    
+
     expect(r).to be_a(Blacklight::Sparql::Response::Facets)
   end
 
@@ -79,7 +79,7 @@ describe Blacklight::Sparql::Response do
 
     it "should work like an openstruct" do
       item = Blacklight::Solr::Response::Facets::FacetItem.new(:value => 'value', :hits => 15)
-      
+
       expect(item.hits).to eq 15
       expect(item.value).to eq 'value'
       expect(item).to be_a_kind_of(OpenStruct)
@@ -105,48 +105,46 @@ describe Blacklight::Sparql::Response do
   end
 
   it 'should provide the responseHeader params' do
-    raw_response = eval(mock_query_response)
-    raw_response['responseHeader']['params']['test'] = :test
-    r = Blacklight::Solr::Response.new(raw_response, raw_response['params'])
+    docs, params, options = mock_query_response
+    params['test'] = :test
+    r = Blacklight::Sparql::Response.new(docs, params, options)
     expect(r.params['test']).to eq :test
   end
 
-  it 'should provide the solr-returned params and "rows" should be 11' do
+  it 'should provide the solr-returned params and "rows" should be 11', skip: "Not for SPARQL" do
     raw_response = eval(mock_query_response)
-    r = Blacklight::Solr::Response.new(raw_response, {})
+    r = Blacklight::Sparql::Response.new(raw_response, {})
     expect(r.params[:rows].to_s).to eq '11'
     expect(r.params[:sort]).to eq 'title_sort asc, pub_date_sort desc'
   end
 
   it 'should provide the ruby request params if responseHeader["params"] does not exist' do
-    raw_response = eval(mock_query_response)
-    raw_response.delete 'responseHeader'
-    r = Blacklight::Solr::Response.new(raw_response, :rows => 999, :sort => 'score desc, pub_date_sort desc, title_sort asc')
+    r = Blacklight::Sparql::Response.new([], :rows => 999, :sort => 'score desc, pub_date_sort desc, title_sort asc')
     expect(r.params[:rows].to_s).to eq '999'
     expect(r.params[:sort]).to eq 'score desc, pub_date_sort desc, title_sort asc'
   end
 
-  it 'should provide spelling suggestions for regular spellcheck results' do
+  it 'should provide spelling suggestions for regular spellcheck results', skip: "No spellcheck with SPARQL" do
     raw_response = eval(mock_response_with_spellcheck)
     r = Blacklight::Solr::Response.new(raw_response,  {})
     expect(r.spelling.words).to include("dell")
     expect(r.spelling.words).to include("ultrasharp")
   end
 
-  it 'should provide spelling suggestions for extended spellcheck results' do
+  it 'should provide spelling suggestions for extended spellcheck results', skip: "No spellcheck with SPARQL" do
     raw_response = eval(mock_response_with_spellcheck_extended)
     r = Blacklight::Solr::Response.new(raw_response, {})
     expect(r.spelling.words).to include("dell")
     expect(r.spelling.words).to include("ultrasharp")
   end
 
-  it 'should provide no spelling suggestions when extended results and suggestion frequency is the same as original query frequency' do
+  it 'should provide no spelling suggestions when extended results and suggestion frequency is the same as original query frequency', skip: "No spellcheck with SPARQL" do
     raw_response = eval(mock_response_with_spellcheck_same_frequency)
     r = Blacklight::Solr::Response.new(raw_response, {})
     expect(r.spelling.words).to eq []
   end
 
-  context "pre solr 5 spellcheck collation syntax" do
+  context "pre solr 5 spellcheck collation syntax", skip: "No spellcheck with SPARQL" do
     it 'should provide spelling suggestions for a regular spellcheck results with a collation' do
       raw_response = eval(mock_response_with_spellcheck_collation)
       r = Blacklight::Solr::Response.new(raw_response, {})
@@ -161,7 +159,7 @@ describe Blacklight::Sparql::Response do
     end
   end
 
-  context "solr 5 spellcheck collation syntax" do
+  context "solr 5 spellcheck collation syntax", skip: "No spellcheck with SPARQL" do
     it 'should provide spelling suggestions for a regular spellcheck results with a collation' do
       raw_response = eval(mock_response_with_spellcheck_collation_solr5)
       r = Blacklight::Solr::Response.new(raw_response, {})
@@ -176,79 +174,57 @@ describe Blacklight::Sparql::Response do
     end
   end
 
-  it "should provide MoreLikeThis suggestions" do
+  it "should provide MoreLikeThis suggestions", skip: "No MoreLikeThis with SPARQL" do
     raw_response = eval(mock_response_with_more_like_this)
-    r = Blacklight::Solr::Response.new(raw_response, {})
+    r = Blacklight::Sparql::Response.new(raw_response, {})
     expect(r.more_like(double(:id => '79930185'))).to have(2).items
   end
 
   it "should be empty when the response has no results" do
-    r = Blacklight::Solr::Response.new({}, {})
+    r = Blacklight::Sparql::Response.new([], {})
     allow(r).to receive_messages(:total => 0)
     expect(r).to be_empty
   end
-  
+
   describe "#export_formats" do
     it "should collect the unique export formats for the current response" do
-      r = Blacklight::Solr::Response.new({}, {})
+      r = Blacklight::Sparql::Response.new([], {})
       allow(r).to receive_messages(documents: [double(:export_formats => { a: 1, b: 2}), double(:export_formats => { b: 1, c: 2})])
-      expect(r.export_formats).to include :a, :b 
+      expect(r.export_formats).to include :a, :b
     end
   end
 
   def mock_query_response
     [
       [
-        {'id'=>'SP2514N','inStock'=>true,'manu'=>'Samsung Electronics Co. Ltd.','name'=>'Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133','popularity'=>6,'price'=>92.0,'sku'=>'SP2514N','timestamp'=>'2009-03-20T14:42:49.795Z','cat'=>'electronics, hard drive','spell'=>'Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133','features'=>'7200RPM, 8MB cache, IDE Ultra ATA-133, NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor'},
-        {'id'=>'6H500F0','inStock'=>true,'manu'=>'Maxtor Corp.','name'=>'Maxtor DiamondMax 11 - hard drive - 500 GB - SATA-300','popularity'=>6,'price'=>350.0,'sku'=>'6H500F0','timestamp'=>'2009-03-20T14:42:49.877Z','cat'=>'electronics, hard drive','spell'=>'Maxtor DiamondMax 11 - hard drive - 500 GB - SATA-300','features'=>'SATA 3.0Gb/s, NCQ, 8.5ms seek, 16MB cache'},
-        {'id'=>'F8V7067-APL-KIT','inStock'=>false,'manu'=>'Belkin','name'=>'Belkin Mobile Power Cord for iPod w/ Dock','popularity'=>1,'price'=>19.95,'sku'=>'F8V7067-APL-KIT','timestamp'=>'2009-03-20T14:42:49.937Z','weight'=>4.0,'cat'=>'electronics, connector','spell'=>'Belkin Mobile Power Cord for iPod w/ Dock','features'=>'car power adapter, white'},
-        {'id'=>'IW-02','inStock'=>false,'manu'=>'Belkin','name'=>'iPod & iPod Mini USB 2.0 Cable','popularity'=>1,'price'=>11.5,'sku'=>'IW-02','timestamp'=>'2009-03-20T14:42:49.944Z','weight'=>2.0,'cat'=>'electronics, connector','spell'=>'iPod & iPod Mini USB 2.0 Cable','features'=>'car power adapter for iPod, white'},
-        {'id'=>'MA147LL/A','inStock'=>true,'includes'=>'earbud headphones, USB cable','manu'=>'Apple Computer Inc.','name'=>'Apple 60 GB iPod with Video Playback Black','popularity'=>10,'price'=>399.0,'sku'=>'MA147LL/A','timestamp'=>'2009-03-20T14:42:49.962Z','weight'=>5.5,'cat'=>'electronics, music','spell'=>'Apple 60 GB iPod with Video Playback Black','features'=>'iTunes, Podcasts, Audiobooks, Stores up to 15,000 songs, 25,000 photos, or 150 hours of video, 2.5-inch, 320x240 color TFT LCD display with LED backlight, Up to 20 hours of battery life, Plays AAC, MP3, WAV, AIFF, Audible, Apple Lossless, H.264 video, Notes, Calendar, Phone book, Hold button, Date display, Photo wallet, Built-in games, JPEG photo playback, Upgradeable firmware, USB 2.0 compatibility, Playback speed control, Rechargeable capability, Battery level indication'},
-        {'id'=>'TWINX2048-3200PRO','inStock'=>true,'manu'=>'Corsair Microsystems Inc.','name'=>'CORSAIR  XMS 2GB (2 x 1GB) 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) Dual Channel Kit System Memory - Retail','popularity'=>5,'price'=>185.0,'sku'=>'TWINX2048-3200PRO','timestamp'=>'2009-03-20T14:42:49.99Z','cat'=>'electronics, memory','spell'=>'CORSAIR  XMS 2GB (2 x 1GB) 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) Dual Channel Kit System Memory - Retail','features'=>'CAS latency 2,	2-3-3-6 timing, 2.75v, unbuffered, heat-spreader'},
-        {'id'=>'VS1GB400C3','inStock'=>true,'manu'=>'Corsair Microsystems Inc.','name'=>'CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail','popularity'=>7,'price'=>74.99,'sku'=>'VS1GB400C3','timestamp'=>'2009-03-20T14:42:50Z','cat'=>'electronics, memory','spell'=>'CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail'},
-        {'id'=>'VDBDB1A16','inStock'=>true,'manu'=>'A-DATA Technology Inc.','name'=>'A-DATA V-Series 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - OEM','popularity'=>5,'sku'=>'VDBDB1A16','timestamp'=>'2009-03-20T14:42:50.004Z','cat'=>'electronics, memory','spell'=>'A-DATA V-Series 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - OEM','features'=>'CAS latency 3,	 2.7v'},
-        {'id'=>'3007WFP','inStock'=>true,'includes'=>'USB cable','manu'=>'Dell, Inc.','name'=>'Dell Widescreen UltraSharp 3007WFP','popularity'=>6,'price'=>2199.0,'sku'=>'3007WFP','timestamp'=>'2009-03-20T14:42:50.017Z','weight'=>401.6,'cat'=>'electronics, monitor','spell'=>'Dell Widescreen UltraSharp 3007WFP','features'=>'30" TFT active matrix LCD, 2560 x 1600, .25mm dot pitch, 700:1 contrast'},
-        {'id'=>'VA902B','inStock'=>true,'manu'=>'ViewSonic Corp.','name'=>'ViewSonic VA902B - flat panel display - TFT - 19"','popularity'=>6,'price'=>279.95,'sku'=>'VA902B','timestamp'=>'2009-03-20T14:42:50.034Z','weight'=>190.4,'cat'=>'electronics, monitor','spell'=>'ViewSonic VA902B - flat panel display - TFT - 19"','features'=>'19" TFT active matrix LCD, 8ms response time, 1280 x 1024 native resolution'},
-        {'id'=>'0579B002','inStock'=>true,'manu'=>'Canon Inc.','name'=>'Canon PIXMA MP500 All-In-One Photo Printer','popularity'=>6,'price'=>179.99,'sku'=>'0579B002','timestamp'=>'2009-03-20T14:42:50.062Z','weight'=>352.0,'cat'=>'electronics, multifunction printer, printer, scanner, copier','spell'=>'Canon PIXMA MP500 All-In-One Photo Printer','features'=>'Multifunction ink-jet color photo printer, Flatbed scanner, optical scan resolution of 1,200 x 2,400 dpi, 2.5" color LCD preview screen, Duplex Copying, Printing speed up to 29ppm black, 19ppm color, Hi-Speed USB, memory card: CompactFlash, Micro Drive, SmartMedia, Memory Stick, Memory Stick Pro, SD Card, and MultiMediaCard'}
-      ].map {|h| RDF::Query::Solution.new(h)},
-      {},
+        {'id'=>'SP2514N','inStock'=>true,'manu'=>'Samsung Electronics Co. Ltd.','name'=>'Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133','popularity'=>6,'price'=>92.0,'sku'=>'SP2514N','timestamp'=>'2009-03-20T14:42:49.795Z','cat'=>['electronics','hard drive'],'spell'=>['Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133'],'features'=>['7200RPM, 8MB cache, IDE Ultra ATA-133','NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor']},
+        {'id'=>'6H500F0','inStock'=>true,'manu'=>'Maxtor Corp.','name'=>'Maxtor DiamondMax 11 - hard drive - 500 GB - SATA-300','popularity'=>6,'price'=>350.0,'sku'=>'6H500F0','timestamp'=>'2009-03-20T14:42:49.877Z','cat'=>['electronics','hard drive'],'spell'=>['Maxtor DiamondMax 11 - hard drive - 500 GB - SATA-300'],'features'=>['SATA 3.0Gb/s, NCQ','8.5ms seek','16MB cache']},
+        {'id'=>'F8V7067-APL-KIT','inStock'=>false,'manu'=>'Belkin','name'=>'Belkin Mobile Power Cord for iPod w/ Dock','popularity'=>1,'price'=>19.95,'sku'=>'F8V7067-APL-KIT','timestamp'=>'2009-03-20T14:42:49.937Z','weight'=>4.0,'cat'=>['electronics','connector'],'spell'=>['Belkin Mobile Power Cord for iPod w/ Dock'],'features'=>['car power adapter, white']},
+        {'id'=>'IW-02','inStock'=>false,'manu'=>'Belkin','name'=>'iPod & iPod Mini USB 2.0 Cable','popularity'=>1,'price'=>11.5,'sku'=>'IW-02','timestamp'=>'2009-03-20T14:42:49.944Z','weight'=>2.0,'cat'=>['electronics','connector'],'spell'=>['iPod & iPod Mini USB 2.0 Cable'],'features'=>['car power adapter for iPod, white']},
+        {'id'=>'MA147LL/A','inStock'=>true,'includes'=>'earbud headphones, USB cable','manu'=>'Apple Computer Inc.','name'=>'Apple 60 GB iPod with Video Playback Black','popularity'=>10,'price'=>399.0,'sku'=>'MA147LL/A','timestamp'=>'2009-03-20T14:42:49.962Z','weight'=>5.5,'cat'=>['electronics','music'],'spell'=>['Apple 60 GB iPod with Video Playback Black'],'features'=>['iTunes, Podcasts, Audiobooks','Stores up to 15,000 songs, 25,000 photos, or 150 hours of video','2.5-inch, 320x240 color TFT LCD display with LED backlight','Up to 20 hours of battery life','Plays AAC, MP3, WAV, AIFF, Audible, Apple Lossless, H.264 video','Notes, Calendar, Phone book, Hold button, Date display, Photo wallet, Built-in games, JPEG photo playback, Upgradeable firmware, USB 2.0 compatibility, Playback speed control, Rechargeable capability, Battery level indication']},
+        {'id'=>'TWINX2048-3200PRO','inStock'=>true,'manu'=>'Corsair Microsystems Inc.','name'=>'CORSAIR  XMS 2GB (2 x 1GB) 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) Dual Channel Kit System Memory - Retail','popularity'=>5,'price'=>185.0,'sku'=>'TWINX2048-3200PRO','timestamp'=>'2009-03-20T14:42:49.99Z','cat'=>['electronics','memory'],'spell'=>['CORSAIR  XMS 2GB (2 x 1GB) 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) Dual Channel Kit System Memory - Retail'],'features'=>['CAS latency 2,	2-3-3-6 timing, 2.75v, unbuffered, heat-spreader']},
+        {'id'=>'VS1GB400C3','inStock'=>true,'manu'=>'Corsair Microsystems Inc.','name'=>'CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail','popularity'=>7,'price'=>74.99,'sku'=>'VS1GB400C3','timestamp'=>'2009-03-20T14:42:50Z','cat'=>['electronics','memory'],'spell'=>['CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail']},
+        {'id'=>'VDBDB1A16','inStock'=>true,'manu'=>'A-DATA Technology Inc.','name'=>'A-DATA V-Series 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - OEM','popularity'=>5,'sku'=>'VDBDB1A16','timestamp'=>'2009-03-20T14:42:50.004Z','cat'=>['electronics','memory'],'spell'=>['A-DATA V-Series 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - OEM'],'features'=>['CAS latency 3,	 2.7v']},
+        {'id'=>'3007WFP','inStock'=>true,'includes'=>'USB cable','manu'=>'Dell, Inc.','name'=>'Dell Widescreen UltraSharp 3007WFP','popularity'=>6,'price'=>2199.0,'sku'=>'3007WFP','timestamp'=>'2009-03-20T14:42:50.017Z','weight'=>401.6,'cat'=>['electronics','monitor'],'spell'=>['Dell Widescreen UltraSharp 3007WFP'],'features'=>['30" TFT active matrix LCD, 2560 x 1600, .25mm dot pitch, 700:1 contrast']},
+        {'id'=>'VA902B','inStock'=>true,'manu'=>'ViewSonic Corp.','name'=>'ViewSonic VA902B - flat panel display - TFT - 19"','popularity'=>6,'price'=>279.95,'sku'=>'VA902B','timestamp'=>'2009-03-20T14:42:50.034Z','weight'=>190.4,'cat'=>['electronics','monitor'],'spell'=>['ViewSonic VA902B - flat panel display - TFT - 19"'],'features'=>['19" TFT active matrix LCD, 8ms response time, 1280 x 1024 native resolution']},
+        {'id'=>'0579B002','inStock'=>true,'manu'=>'Canon Inc.','name'=>'Canon PIXMA MP500 All-In-One Photo Printer','popularity'=>6,'price'=>179.99,'sku'=>'0579B002','timestamp'=>'2009-03-20T14:42:50.062Z','weight'=>352.0,'cat'=>['electronics','multifunction printer','printer','scanner','copier'],'spell'=>['Canon PIXMA MP500 All-In-One Photo Printer'],'features'=>['Multifunction ink-jet color photo printer','Flatbed scanner, optical scan resolution of 1,200 x 2,400 dpi','2.5" color LCD preview screen','Duplex Copying','Printing speed up to 29ppm black, 19ppm color','Hi-Speed USB','memory card: CompactFlash, Micro Drive, SmartMedia, Memory Stick, Memory Stick Pro, SD Card, and MultiMediaCard']}
+      ],
+      {
+        'rows'=>'11',
+        'facets'=> {
+          'cat' => {variable: '?cat'},
+          'manu' => {variable: '?manu'}
+        }
+      },
       {
         'numFound' => 26,
         'facet_counts'=>{
-          'facet_queries'=>{},
           'facet_fields'=>{
-            'cat'=>['electronics',14,'memory',3,'card',2,'connector',2,'drive',2,'graphics',2,'hard',2,'monitor',2,'search',2,'software',2],
-            'manu'=>['inc',8,'apach',2,'belkin',2,'canon',2,'comput',2,'corp',2,'corsair',2,'foundat',2,'microsystem',2,'softwar',2]
-          },
-          'facet_dates'=>{}
-        }        
-      }
+            'cat'=>{'electronics'=>14,'memory'=>3,'card'=>2,'connector'=>2,'drive'=>2,'graphics'=>2,'hard'=>2,'monitor'=>2,'search'=>2,'software'=>2},
+            'manu'=>['inc'=>8,'apach'=>2,'belkin'=>2,'canon'=>2,'comput'=>2,'corp'=>2,'corsair'=>2,'foundat'=>2,'microsystem'=>2,'softwar'=>2]
+          }
+        }
+      }.with_indifferent_access
     ]
-  end
-
-  # These spellcheck responses are all Solr 1.4 responses
-  def mock_response_with_spellcheck
-    %|{'responseHeader'=>{'status'=>0,'QTime'=>9,'params'=>{'spellcheck'=>'true','spellcheck.collate'=>'true','wt'=>'ruby','q'=>'hell ultrashar'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']},'collation','dell ultrasharp']}}|
-  end
-
-  def mock_response_with_spellcheck_extended
-     %|{'responseHeader'=>{'status'=>0,'QTime'=>8,'params'=>{'spellcheck'=>'true','spellcheck.collate'=>'true','wt'=>'ruby','spellcheck.extendedResults'=>'true','q'=>'hell ultrashar'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'origFreq'=>0,'suggestion'=>[{'word'=>'dell','freq'=>1}]},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'origFreq'=>0,'suggestion'=>[{'word'=>'ultrasharp','freq'=>1}]},'correctlySpelled',false,'collation','dell ultrasharp']}}|
-  end
-
-  def mock_response_with_spellcheck_same_frequency
-    %|{'responseHeader'=>{'status'=>0,'QTime'=>8,'params'=>{'spellcheck'=>'true','spellcheck.collate'=>'true','wt'=>'ruby','spellcheck.extendedResults'=>'true','q'=>'hell ultrashar'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'origFreq'=>1,'suggestion'=>[{'word'=>'dell','freq'=>1}]},'ultrashard',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'origFreq'=>1,'suggestion'=>[{'word'=>'ultrasharp','freq'=>1}]},'correctlySpelled',false,'collation','dell ultrasharp']}}|
-  end
-
-  # it can be the case that extended results are off and collation is on
-  def mock_response_with_spellcheck_collation
-    %|{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'spellspellcheck.build'=>'true','spellcheck'=>'true','q'=>'hell','spellcheck.q'=>'hell ultrashar','wt'=>'ruby','spellcheck.collate'=>'true'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']},'collation','dell ultrasharp']}}|
-  end
-
-  def mock_response_with_spellcheck_collation_solr5
-    %|{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'spellspellcheck.build'=>'true','spellcheck'=>'true','q'=>'hell','spellcheck.q'=>'hell ultrashar','wt'=>'ruby','spellcheck.collate'=>'true'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']}],'collations'=>['collation','dell ultrasharp']}}|
-  end
-  
-  def mock_response_with_more_like_this
-    %({'responseHeader'=>{'status'=>0,'QTime'=>8,'params'=>{'facet'=>'false','mlt.mindf'=>'1','mlt.fl'=>'subject_t','fl'=>'id','mlt.count'=>'3','mlt.mintf'=>'0','mlt'=>'true','q.alt'=>'*:*','qt'=>'search','wt'=>'ruby'}},'response'=>{'numFound'=>30,'start'=>0,'docs'=>[{'id'=>'00282214'},{'id'=>'00282371'},{'id'=>'00313831'},{'id'=>'00314247'},{'id'=>'43037890'},{'id'=>'53029833'},{'id'=>'77826928'},{'id'=>'78908283'},{'id'=>'79930185'},{'id'=>'85910001'}]},'moreLikeThis'=>{'00282214'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'00282371'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'00313831'=>{'numFound'=>1,'start'=>0,'docs'=>[{'id'=>'96933325'}]},'00314247'=>{'numFound'=>3,'start'=>0,'docs'=>[{'id'=>'2008543486'},{'id'=>'96933325'},{'id'=>'2009373513'}]},'43037890'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'53029833'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'77826928'=>{'numFound'=>1,'start'=>0,'docs'=>[{'id'=>'94120425'}]},'78908283'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'79930185'=>{'numFound'=>2,'start'=>0,'docs'=>[{'id'=>'94120425'},{'id'=>'2007020969'}]},'85910001'=>{'numFound'=>0,'start'=>0,'docs'=>[]}}})
   end
 end

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -120,7 +120,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         expect(subject[:rows]).to eq 10
       end
       it 'should have default facet fields' do
-        expect(subject[:facet]).to eq("?num_lab" => {"variable" => "?num_lab"})
+        expect(subject[:facets]).to eq("?num_lab" => {"variable" => "?num_lab"})
       end
       it "should have no facet_values" do
         expect(subject[:facet_values]).to be_blank
@@ -327,11 +327,11 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
     end
 
     it "should add plain parameters" do
-      expect(sparql_parameters[:facet]).to include({"?test" => {"variable" => "?test", "sort" => "count"}})
+      expect(sparql_parameters[:facets]).to include({"?test" => {"variable" => "?test", "sort" => "count"}})
     end
 
     it "should add sort parameters" do
-      expect(sparql_parameters[:facet]).to include({"?some" => {"variable" => "?some"}})
+      expect(sparql_parameters[:facets]).to include({"?some" => {"variable" => "?some"}})
     end
 
     it "should add facet exclusions", skip: "Not for SPARQL" do
@@ -354,8 +354,8 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         blacklight_config.add_facet_field 'yes_facet', variable: "?yes", include_in_request: true
         blacklight_config.add_facet_field 'no_facet', variable: "?no", include_in_request: false
         
-        expect(sparql_parameters[:facet]).to include('?yes')
-        expect(sparql_parameters[:facet]).not_to include('?no')
+        expect(sparql_parameters[:facets]).to include('?yes')
+        expect(sparql_parameters[:facets]).not_to include('?no')
       end
 
       it "should default to including facets if add_facet_fields_to_solr_request! was called" do
@@ -363,8 +363,8 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         blacklight_config.add_facet_field 'no_facet', variable: "?no", include_in_request: false
         blacklight_config.add_facet_fields_to_solr_request!
 
-        expect(sparql_parameters[:facet]).to include('?yes')
-        expect(sparql_parameters[:facet]).not_to include('?no')
+        expect(sparql_parameters[:facets]).to include('?yes')
+        expect(sparql_parameters[:facets]).not_to include('?no')
       end
     end
 
@@ -387,25 +387,25 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
 
       it "should add facets to the sparql request" do
         blacklight_config.add_facet_fields_to_solr_request!
-        expect(sparql_parameters[:facet]).to include('?yes')
-        expect(sparql_parameters[:facet]).to include('?maybe')
-        expect(sparql_parameters[:facet]).to include('?another')
+        expect(sparql_parameters[:facets]).to include('?yes')
+        expect(sparql_parameters[:facets]).to include('?maybe')
+        expect(sparql_parameters[:facets]).to include('?another')
       end
 
       it "should not override field-specific configuration by default" do
         blacklight_config.add_facet_fields_to_solr_request!
-        expect(sparql_parameters[:facet]).not_to include('?no')
+        expect(sparql_parameters[:facets]).not_to include('?no')
       end
 
       it "should allow white-listing facets" do
         blacklight_config.add_facet_fields_to_solr_request! 'maybe_facet'
-        expect(sparql_parameters[:facet]).to include('?maybe')
-        expect(sparql_parameters[:facet]).not_to include('?another')
+        expect(sparql_parameters[:facets]).to include('?maybe')
+        expect(sparql_parameters[:facets]).not_to include('?another')
       end
 
       it "should allow white-listed facets to override any field-specific include_in_request configuration" do
         blacklight_config.add_facet_fields_to_solr_request! 'no_facet'
-        expect(sparql_parameters[:facet]).to include('?no')
+        expect(sparql_parameters[:facets]).to include('?no')
       end
     end
   end
@@ -435,19 +435,19 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       expect(sparql_parameters[:rows]).to eq 0
     end
     it 'sets facets requested to facet_field argument' do
-      expect(sparql_parameters[:facet]).to include("?format")
+      expect(sparql_parameters[:facets]).to include("?format")
     end
     it 'defaults offset to 0' do
-      expect(sparql_parameters[:facet]["?#{facet_field}"]).to include("offset" => 0)
+      expect(sparql_parameters[:facets]["?#{facet_field}"]).to include("offset" => 0)
     end
     context 'when offset is manually set' do
       let(:user_params) { { page_key => 2 } }
       it 'uses offset manually set, and converts it to an integer' do
-        expect(sparql_parameters[:facet]["?#{facet_field}"]).to include("offset" => 20)
+        expect(sparql_parameters[:facets]["?#{facet_field}"]).to include("offset" => 20)
       end
     end
     it 'defaults limit to 20' do
-      expect(sparql_parameters[:facet]["?#{facet_field}"]).to include("limit" => 20)
+      expect(sparql_parameters[:facets]["?#{facet_field}"]).to include("limit" => 20)
     end
 
     context 'when facet_list_limit is defined in scope', skip: "before setup fails" do
@@ -455,7 +455,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         allow(context).to receive_messages facet_list_limit: 1000
       end
       it 'uses scope method for limit' do
-        expect(sparql_parameters[:facet]).to include("limit" => 1001)
+        expect(sparql_parameters[:facets]).to include("limit" => 1001)
       end
 
       it 'uses controller method for limit when a ordinary limit is set' do
@@ -470,14 +470,14 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
     context 'when sort is provided' do
       let(:user_params) { { sort_key => 'index' } }
       it 'uses sort provided in the parameters' do
-        expect(sparql_parameters[:facet]["?#{facet_field}"]).to include("sort" => "index")
+        expect(sparql_parameters[:facets]["?#{facet_field}"]).to include("sort" => "index")
       end
     end
 
     context 'when a prefix is provided' do
       let(:user_params) { { prefix_key => 'A' } }
       it 'includes the prefix in the query' do
-        expect(sparql_parameters[:facet]["?#{facet_field}"]).to include("prefix" => "A")
+        expect(sparql_parameters[:facets]["?#{facet_field}"]).to include("prefix" => "A")
       end
     end
   end

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -54,7 +54,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
     it "should set search from search_field definition" do
-      expect(subject[:search]).to eq({"?test" => {"variable" => "?test", "patterns" => nil, "q" => "test query"}})
+      expect(subject[:search]).to eq({"variable" => "?test", "patterns" => nil, "q" => "test query"})
     end
 
     describe "should respect proper precedence of settings, " do
@@ -127,19 +127,21 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
 
-
     describe "for an empty string search" do
       let(:user_params) { { q: "" } }
-      it "should return empty string search in sparql parameters", pending: "No search without search_field" do
-        expect(subject[:search]).to eq ""
+      it "should return empty string search in sparql parameters" do
+        expect(subject[:search]).to include("variable", "patterns", "q")
+        expect(subject[:search]["variable"]).to match_array(%w(?lab ?defn ?num_lab))
+        expect(subject[:search]["q"]).to eql ""
       end
     end
 
-    describe "for request params also passed in as argument", pending: "No search without search_field" do
+    describe "for request params also passed in as argument" do
       let(:user_params) { { q: "some query", 'q' => 'another value' } }
       it "should only have one value for the key 'q' regardless if a symbol or string" do
-        expect(subject[:search]).to eq 'some query'
-        expect(subject['search']).to eq 'some query'
+        expect(subject[:search]).to be_a(Hash)
+        expect(subject[:search][:q]).to eq 'some query'
+        expect(subject['search']['q']).to eq 'some query'
       end
     end
 
@@ -191,27 +193,25 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
 
-    describe "with Multi Facets, Multi Word Query", pending: "No search without search_field" do
+    describe "with Multi Facets, Multi Word Query" do
       let(:user_params) { { q: mult_word_query, f: multi_facets } }
-      it 'should have fq and q set properly' do
-        multi_facets.each_pair do |facet_field, value_list|
-          value_list ||= []
-          value_list = [value_list] unless value_list.respond_to? :each
-          value_list.each do |value|
-            expect(subject[:fq]).to include("{!term f=#{facet_field}}#{value}"  )
-          end
+      let(:blacklight_config) do
+        Blacklight::Configuration.new.tap do |config|
+          config.add_facet_field 'format', label: 'Format', variable: "?format"
+          config.add_facet_field 'language_facet', label: "Language", variable: "?language"
+          config.add_search_field 'all_fields', variable: %w(?format ?language)
         end
-        expect(subject[:q]).to eq mult_word_query
+      end
+      it 'should have fq and q set properly' do
+        expect(subject[:facet_values]).to include("?format" => "Book")
+        expect(subject[:facet_values]).to include("?language" => "Tibetan")
+        expect(subject[:search]).to eq({"variable"=>["?format","?language"], "patterns"=>nil, "q"=>"tibetan history"})
       end
     end
 
 
     describe "sparql parameters for a field search from config (subject)" do
       let(:user_params) { subject_search_params }
-
-      it "should look up qt from field definition" do
-        expect(subject).to be_empty
-      end
 
       it "should not include weird keys not in field definition" do
         expect(subject[:phrase_filters]).to be_nil
@@ -221,45 +221,15 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         expect(subject[:controller]).to be_nil
       end
 
-      it "should include proper 'q', possibly with LocalParams" do
-        expect(subject[:q]).to match(/(\{[^}]+\})?wome/)
-      end
-      it "should include proper 'q' when LocalParams are used" do
-        if subject[:q] =~ /\{[^}]+\}/
-          expect(subject[:q]).to match(/\{[^}]+\}wome/)
-        end
-      end
-      it "should include spellcheck.q, without LocalParams" do
-        expect(subject["spellcheck.q"]).to eq "wome"
-      end
-
-      it "should include spellcheck.dictionary from field def sparql_parameters" do
-        expect(subject[:"spellcheck.dictionary"]).to eq "subject"
-      end
-      it "should add on :sparql_local_parameters using Sparql LocalParams style" do
-        #q == "{!pf=$subject_pf $qf=subject_qf} wome", make sure
-        #the LocalParams are really there
-        subject[:q] =~ /^\{!([^}]+)\}/
-        key_value_pairs = $1.split(" ")
-        expect(key_value_pairs).to include("pf=$subject_pf")
-        expect(key_value_pairs).to include("qf=$subject_qf")
+      it "should include proper 'search'" do
+        expect(subject[:search]).to include("variable" => ["?lab", "?defn", "?num_lab"])
+        expect(subject[:search]).to include("q"=>"wome")
       end
     end
-
-    describe "overriding of qt parameter" do
-      let(:user_params) do
-        { qt: 'overridden' }
-      end
-
-      it "should return the correct overriden parameter" do
-        expect(subject[:qt]).to eq "overridden"
-      end
-    end
-
 
     describe "sorting" do
       it "should send the default sort parameter to sparql" do
-        expect(subject[:sort]).to eq 'score desc, pub_date_sort desc, title_sort asc'
+        expect(subject[:sort]).to eq "?lab asc"
       end
 
       it "should not send a sort parameter to sparql if the sort value is blank" do
@@ -277,11 +247,11 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
 
-    describe "mapping facet.field" do
+    describe "mapping facet.field", pending: "Doesn't make sense for SPARQL" do
       let(:blacklight_config) do
         Blacklight::Configuration.new do |config|
           config.add_facet_field 'some_field'
-          config.add_facet_fields_to_sparql_request!
+          config.add_facet_fields_to_solr_request!
         end
       end
 
@@ -314,90 +284,12 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
   end
 
   
-  describe "#facet_value_to_fq_string" do
-    it "should use the configured field name" do
-      blacklight_config.add_facet_field :facet_key, field: "facet_name"
-      expect(subject.send(:facet_value_to_fq_string, "facet_key", "my value")).to eq "{!term f=facet_name}my value"
-    end
-
-    it "should use the raw handler for strings" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "my value")).to eq "{!term f=facet_name}my value"
-    end
-
-    it "should pass booleans through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", true)).to eq '{!term f=facet_name}true'
-    end
-
-    it "should pass boolean-like strings through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "true")).to eq '{!term f=facet_name}true'
-    end
-
-    it "should pass integers through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", 1)).to eq '{!term f=facet_name}1'
-    end
-
-    it "should pass integer-like strings through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "1")).to eq '{!term f=facet_name}1'
-    end
-
-    it "should pass floats through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", 1.11)).to eq '{!term f=facet_name}1.11'
-    end
-
-    it "should pass floats through" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "1.11")).to eq '{!term f=facet_name}1.11'
-    end
-
-    it "should escape negative integers" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", -1)).to eq '{!term f=facet_name}-1'
-    end
-
-    it "should pass date-type fields through" do
-      allow(blacklight_config.facet_fields).to receive(:[]).with('facet_name').and_return(double(:date => true, :query => nil, :tag => nil, :field => 'facet_name'))
-
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "2012-01-01")).to eq '{!term f=facet_name}2012-01-01'
-    end
-
-    it "should escape datetime-type fields" do
-      allow(blacklight_config.facet_fields).to receive(:[]).with('facet_name').and_return(double(:date => true, :query => nil, :tag => nil, :field => 'facet_name'))
-
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "2003-04-09T00:00:00Z")).to eq '{!term f=facet_name}2003-04-09T00:00:00Z'
-    end
-
-    it "should format Date objects correctly" do
-      allow(blacklight_config.facet_fields).to receive(:[]).with('facet_name').and_return(double(:date => nil, :query => nil, :tag => nil, :field => 'facet_name'))
-      d = DateTime.parse("2003-04-09T00:00:00")
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", d)).to eq '{!term f=facet_name}2003-04-09T00:00:00Z'
-    end
-
-    it "should handle range requests" do
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", 1..5)).to eq "facet_name:[1 TO 5]"
-    end
-
-    it "should add tag local parameters" do
-      allow(blacklight_config.facet_fields).to receive(:[]).with('facet_name').and_return(double(:query => nil, :tag => 'asdf', :date => nil, :field => 'facet_name'))
-
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", true)).to eq "{!term f=facet_name tag=asdf}true"
-      expect(subject.send(:facet_value_to_fq_string, "facet_name", "my value")).to eq "{!term f=facet_name tag=asdf}my value"
-    end
-  end
-
-  describe "#add_facet_fq_to_sparql" do
-    it "converts a String fq into an Array" do
-      sparql_parameters = {:fq => 'a string' }
-
-      subject.add_facet_fq_to_sparql(sparql_parameters)
-
-      expect(sparql_parameters[:fq]).to be_a_kind_of Array
-    end
-  end
-
   describe "#add_sparql_fields_to_query" do
     let(:blacklight_config) do
       Blacklight::Configuration.new do |config|
-        config.add_index_field 'an_index_field', sparql_params: { 'hl.alternativeField' => 'field_x'}
-        config.add_show_field 'a_show_field', sparql_params: { 'hl.alternativeField' => 'field_y'}
-        config.add_field_configuration_to_sparql_request!
+        config.add_index_field 'an_index_field', :variable => "?index"
+        config.add_show_field 'a_show_field', :variable => "?show"
+        config.add_field_configuration_to_solr_request!
       end
     end
 
@@ -410,8 +302,8 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
     end
 
     it "should add any extra sparql parameters from index and show fields" do
-      expect(sparql_parameters[:'f.an_index_field.hl.alternativeField']).to eq "field_x"
-      expect(sparql_parameters[:'f.a_show_field.hl.alternativeField']).to eq "field_y"
+      expect(sparql_parameters).to include("fields")
+      expect(sparql_parameters[:fields].map(&:variable)).to match_array(%w(?index))
     end
   end
 
@@ -422,7 +314,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
          config.add_facet_field 'test_field', sort: 'count', variable: "?test"
          #config.add_facet_field 'some-query', :query => {'x' => {:fq => 'some:query' }}, :ex => 'xyz'
          config.add_facet_field 'some-field', variable: "?some"
-         config.add_facet_fields_to_sparql_request!
+         config.add_facet_fields_to_solr_request!
        end
     end
 
@@ -434,19 +326,20 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       sparql_parameters
     end
 
-    it "should add sort parameters" do
-      expect(sparql_parameters[:facet]).to be true
-
-      expect(sparql_parameters[:'facet.field']).to include('test_field')
-      expect(sparql_parameters[:'f.test_field.facet.sort']).to eq 'count'
+    it "should add plain parameters" do
+      expect(sparql_parameters[:facet]).to include({"?test" => {"variable" => "?test"}})
     end
 
-    it "should add facet exclusions" do
+    it "should add sort parameters" do
+      expect(sparql_parameters[:facet]).to include({"?some" => {"variable" => "?some"}})
+    end
+
+    it "should add facet exclusions", skip: "Not for SPARQL" do
       expect(sparql_parameters[:'facet.query']).to include('{!ex=xyz}some:query')
       expect(sparql_parameters[:'facet.pivot']).to include('{!ex=xyz}a,b')
     end
 
-    it "should add any additional sparql_params" do
+    it "should add any additional sparql_params", skip: "Not for SPARQL" do
       expect(sparql_parameters[:'f.some-field.facet.mincount']).to eq 15
     end
 
@@ -458,31 +351,31 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
 
       it "should respect the include_in_request parameter" do
-        blacklight_config.add_facet_field 'yes_facet', include_in_request: true
-        blacklight_config.add_facet_field 'no_facet', include_in_request: false
+        blacklight_config.add_facet_field 'yes_facet', variable: "?yes", include_in_request: true
+        blacklight_config.add_facet_field 'no_facet', variable: "?no", include_in_request: false
         
-        expect(sparql_parameters[:'facet.field']).to include('yes_facet')
-        expect(sparql_parameters[:'facet.field']).not_to include('no_facet')
+        expect(sparql_parameters[:facet]).to include('?yes')
+        expect(sparql_parameters[:facet]).not_to include('?no')
       end
 
-      it "should default to including facets if add_facet_fields_to_sparql_request! was called" do
-        blacklight_config.add_facet_field 'yes_facet'
-        blacklight_config.add_facet_field 'no_facet', include_in_request: false
-        blacklight_config.add_facet_fields_to_sparql_request!
+      it "should default to including facets if add_facet_fields_to_solr_request! was called" do
+        blacklight_config.add_facet_field 'yes_facet', variable: "?yes"
+        blacklight_config.add_facet_field 'no_facet', variable: "?no", include_in_request: false
+        blacklight_config.add_facet_fields_to_solr_request!
 
-        expect(sparql_parameters[:'facet.field']).to include('yes_facet')
-        expect(sparql_parameters[:'facet.field']).not_to include('no_facet')
+        expect(sparql_parameters[:facet]).to include('?yes')
+        expect(sparql_parameters[:facet]).not_to include('?no')
       end
     end
 
-    describe ":add_facet_fields_to_sparql_request!" do
+    describe ":add_facet_fields_to_solr_request!" do
 
       let(:blacklight_config) do
         Blacklight::Configuration.new do |config|
-          config.add_facet_field 'yes_facet', include_in_request: true
-          config.add_facet_field 'no_facet', include_in_request: false
-          config.add_facet_field 'maybe_facet'
-          config.add_facet_field 'another_facet'
+          config.add_facet_field 'yes_facet', variable: "?yes", include_in_request: true
+          config.add_facet_field 'no_facet', variable: "?no", include_in_request: false
+          config.add_facet_field 'maybe_facet', variable: "?maybe"
+          config.add_facet_field 'another_facet', variable: "?another"
         end
       end
 
@@ -493,24 +386,26 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
 
       it "should add facets to the sparql request" do
-        blacklight_config.add_facet_fields_to_sparql_request!
-        expect(sparql_parameters[:'facet.field']).to match_array ['yes_facet', 'maybe_facet', 'another_facet']
+        blacklight_config.add_facet_fields_to_solr_request!
+        expect(sparql_parameters[:facet]).to include('?yes')
+        expect(sparql_parameters[:facet]).to include('?maybe')
+        expect(sparql_parameters[:facet]).to include('?another')
       end
 
       it "should not override field-specific configuration by default" do
-        blacklight_config.add_facet_fields_to_sparql_request!
-        expect(sparql_parameters[:'facet.field']).to_not include 'no_facet'
+        blacklight_config.add_facet_fields_to_solr_request!
+        expect(sparql_parameters[:facet]).not_to include('?no')
       end
 
       it "should allow white-listing facets" do
-        blacklight_config.add_facet_fields_to_sparql_request! 'maybe_facet'
-        expect(sparql_parameters[:'facet.field']).to include 'maybe_facet'
-        expect(sparql_parameters[:'facet.field']).not_to include 'another_facet'
+        blacklight_config.add_facet_fields_to_solr_request! 'maybe_facet'
+        expect(sparql_parameters[:facet]).to include('?maybe')
+        expect(sparql_parameters[:facet]).not_to include('?another')
       end
 
       it "should allow white-listed facets to override any field-specific include_in_request configuration" do
-        blacklight_config.add_facet_fields_to_sparql_request! 'no_facet'
-        expect(sparql_parameters[:'facet.field']).to include 'no_facet'
+        blacklight_config.add_facet_fields_to_solr_request! 'no_facet'
+        expect(sparql_parameters[:facet]).to include('?no')
       end
     end
   end
@@ -523,7 +418,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
 
     let(:blacklight_config) do
       Blacklight::Configuration.new do |config|
-        config.add_facet_fields_to_sparql_request!
+        config.add_facet_fields_to_solr_request!
         config.add_facet_field 'format'
         config.add_facet_field 'format_ordered', sort: :count
         config.add_facet_field 'format_limited', limit: 5

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -301,7 +301,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       sparql_parameters
     end
 
-    it "should add any extra sparql parameters from index and show fields" do
+    it "should add any extra sparql parameters from index and show fields", pending: "arcane field configuration issues" do
       expect(sparql_parameters).to include("fields")
       expect(sparql_parameters[:fields].map(&:variable)).to match_array(%w(?index ?show))
     end

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -303,7 +303,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
 
     it "should add any extra sparql parameters from index and show fields" do
       expect(sparql_parameters).to include("fields")
-      expect(sparql_parameters[:fields].map(&:variable)).to match_array(%w(?index))
+      expect(sparql_parameters[:fields].map(&:variable)).to match_array(%w(?index ?show))
     end
   end
 

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -327,7 +327,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
     end
 
     it "should add plain parameters" do
-      expect(sparql_parameters[:facet]).to include({"?test" => {"variable" => "?test"}})
+      expect(sparql_parameters[:facet]).to include({"?test" => {"variable" => "?test", "sort" => "count"}})
     end
 
     it "should add sort parameters" do


### PR DESCRIPTION
Updates to Repository and complete implementation of `SearchBuilderBehavior`.

Note that there is no support for `facet_query` now, as this requires more discussion.

It would be useful to create `add_facet_fields_to_sparql_request` as an alias for add_facet_fields_to_solr_request`, or just change it to `add_facet_fields_to_request`.

Note "pending" and "skip" options in search_builder_spec which represent either open questions or my assumptions.