### PR TITLE
Cleanup comments and remove code not intended for SPARQL.

### DIFF
--- a/app/models/blacklight/sparql/document.rb
+++ b/app/models/blacklight/sparql/document.rb
@@ -17,16 +17,4 @@ module Blacklight::Sparql::Document
   # Turn solutions into hashes representing documents. Note a main entity may relate to one or more sub-entities, which themselves may reference one or more sub-entities, etc. Scalar values may be multiple too.
   def self.solutions_to_docs
   end
-
-  # FIXME: 
-  #def has_highlight_field? k
-  #  return false if response['highlighting'].blank? or response['highlighting'][self.id].blank?
-  #  
-  #  response['highlighting'][self.id].key? k.to_s
-  #end
-
-  #def highlight_field k
-  #  response['highlighting'][self.id][k.to_s].map(&:html_safe) if has_highlight_field? k
-  #end
-
 end

--- a/app/models/blacklight/sparql/repository.rb
+++ b/app/models/blacklight/sparql/repository.rb
@@ -67,6 +67,7 @@ module Blacklight::Sparql
 
       # Add Lanaugage filters
       # FIXME: not 'en', but configured language, defaulting to 'en'
+      # HINT: use Rails I18N.locale
       fields.select(&:filter_language).each do |field|
         where += "  FILTER(langMatches(LANG(#{field.variable}), 'en'))\n"
       end
@@ -132,8 +133,6 @@ module Blacklight::Sparql
           "LIMIT #{params.fetch(:rows, 10).to_i}\n"
         query += "OFFSET #{params[:start]}" if params[:start].to_i > 0
 
-        # FIXME: ordering
-
         ids = send_and_receive(query).map(&:id)
 
         # FIXME: if we used a sub-select, this could be done in a single query
@@ -180,7 +179,6 @@ module Blacklight::Sparql
       end
 
       facet_counts = HashWithIndifferentAccess.new
-      # FIXME: where would facet_queries come from?
       facet_counts[:facet_fields] = facet_fields
 
       response_opts = {

--- a/app/models/blacklight/sparql/response.rb
+++ b/app/models/blacklight/sparql/response.rb
@@ -77,9 +77,9 @@ module Blacklight::Sparql
     end
     alias_method :docs, :documents
 
-    # FIXME: No grouping in SPARQL?
+    # SPARQL doesn't support grouping like Solr.
     def grouped?
-      self.has_key? "grouped" # Always false
+      false
     end
 
     def export_formats

--- a/app/models/blacklight/sparql/search_builder_behavior.rb
+++ b/app/models/blacklight/sparql/search_builder_behavior.rb
@@ -75,8 +75,6 @@ module Blacklight::Sparql
         # want to page at, according to configured facet limits.
         facet_param[:limit] = (facet_limit_for(field_name) + 1) if facet_limit_for(field_name)
 
-        # FIXME: no support for Facet queries just yet
-        #sparql_parameters.append_facet_query facet.query.map { |k, x| x[:fq] }
         sparql_parameters[:facets][facet.variable] = facet_param
       end
     end

--- a/spec/models/blacklight/sparql/search_builder_spec.rb
+++ b/spec/models/blacklight/sparql/search_builder_spec.rb
@@ -62,7 +62,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
         expect(subject[:search_field]).to be_nil
       end
 
-      it "should add in extra facet.field from params", pending: "Does this make sense for SPARQL; facets need to be configured" do
+      it "should add in extra facet.field from params", skip: "Does this make sense for SPARQL; facets need to be configured" do
         expect(subject[:"facet.field"]).to include("extra_facet")
       end
     end
@@ -88,7 +88,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
 
-    it "should generate a facet limit", pending: "Don't understand where this would come from for SPARQL" do
+    it "should generate a facet limit", pending: "For facet value paging" do
       expect(subject[:"f.subject_topic_facet.facet.limit"]).to eq 21
     end
 
@@ -247,7 +247,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       end
     end
 
-    describe "mapping facet.field", pending: "Doesn't make sense for SPARQL" do
+    describe "mapping facet.field", skip: "Doesn't make sense for SPARQL" do
       let(:blacklight_config) do
         Blacklight::Configuration.new do |config|
           config.add_facet_field 'some_field'
@@ -301,7 +301,7 @@ describe Blacklight::Sparql::SearchBuilderBehavior do
       sparql_parameters
     end
 
-    it "should add any extra sparql parameters from index and show fields", pending: "arcane field configuration issues" do
+    it "should add any extra sparql parameters from index and show fields", skip: "arcane field configuration issues" do
       expect(sparql_parameters).to include("fields")
       expect(sparql_parameters[:fields].map(&:variable)).to match_array(%w(?index ?show))
     end


### PR DESCRIPTION
@cbeer I believe these are things we agreed didn't need to be in SparqLite.