### PR TITLE
Rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,30 @@ Run the server in production mode pointing to the BlazeGraph SPARQL endpoint:
 
     SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite/sparql RAILS_ENV=production bundle exec rails server
 
+### Blazegraph for tests
+
+* Create a new blazegraph namespace, say `sparqlite-test`, using the defaults for a `triples` KB, and select 'use' it.
+* Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
+  * Browse to `db/nomisma.ttl` and select `Update`.  Once the data is loaded into blazegraph, return to the sparqlite console to prepare and run specs:
+
+```
+export SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite-test/sparql
+RAILS_ENV=test bundle exec rake db:test:prepare
+RAILS_ENV=test bundle exec rake db:seed # may not work as expected, but manual loading is done as above
+RAILS_ENV=test bundle exec rake
+
+# To view the test data in the application:
+RAILS_ENV=development bundle exec rails s
+```
+
+### Blazegraph for development (demonstrations)
+
+* Exploring the application is much faster using blazegraph
+* Create a new blazegraph namespace, say `sparqlite-development`, using the defaults for a `triples` KB, and select 'use' it.
+* Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
+  * Browse to `db/nomisma_full.ttl` and select `Update`.  Once the data is loaded into blazegraph, return to the sparqlite console to prepare and run specs:
+
+```
+export SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite-development/sparql
+bundle exec rails s
+```

--- a/README.md
+++ b/README.md
@@ -45,36 +45,27 @@ RAILS_ENV=test bundle exec rake
 
 Service can be run locally using `bundle exec rails server`
 
-### Running on Blazegraph - for macOS
+
+### Running on Blazegraph
+
+#### Installing Blazegraph for macOS
 
 * `brew install blazegraph`
 
 Follow steps to have MongoDB start on login and run `lanuchctl` to start immediately (details may vary):
 
-    sudo cp -fv /usr/local/opt/bigdata/*.plist /Library/LaunchDaemons
-    sudo chown root /Library/LaunchDaemons/homebrew.mxcl.bigdata.plist
+    sudo cp -fv /usr/local/opt/blazegraph/*.plist /Library/LaunchDaemons
+    sudo chown root /Library/LaunchDaemons/homebrew.mxcl.blazegraph.plist
 
-Then to load bigdata now:
+Then to load blazegraph now:
 
-    sudo launchctl load /Library/LaunchDaemons/homebrew.mxcl.bigdata.plist
+    sudo launchctl load /Library/LaunchDaemons/homebrew.mxcl.blazegraph.plist
 
 Or, if you don't want/need launchctl, you can just run:
 
-    bigdata start
+    blazegraph start
 
-Load data using the blazegraph UI at `http://localhost:9999/bigdata/#update`. Browse the file system to select `db/nomisma-full.ttl` and select `Update` control.
-
-Subsequently, perform rails initialization:
-
-* bundle install
-* RAILS_ENV=production bundle exec rake db:migrate
-* RAILS_ENV=production bundle exec rake db:seed
-
-After initializing secrets in config/secrets.yml, run the server in production mode pointing to the BlazeGraph SPARQL endpoint:
-
-    SPARQL_URL=http://localhost:9999/bigdata/sparql RAILS_ENV=production bundle exec rails server
-
-### Running on Blazegraph - for Debian/Ubuntu
+#### Installing Blazegraph for Debian/Ubuntu
 
 Blazegraph installation instructions are at
 * https://github.com/blazegraph/database/tree/master/blazegraph-deb
@@ -84,24 +75,46 @@ MongoDB installation instructions are at
 * https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/
 * once installed, try `sudo service mongodb start`
 
-Create a new blazegraph namespace, say `sparqlite`, using the defaults for
-a `triples` KB, and select 'use' it.  Load data using the blazegraph UI at
-* http://localhost:9999/blazegraph/#update
+### Configuring Blazegraph
 
-Browse to `db/nomisma-full.ttl` and select `Update`.  Once the data is loaded
-into blazegraph, return to the sparqlite console to perform rails initialization:
+#### Production
 
-* bundle install
-* RAILS_ENV=production bundle exec rake db:migrate
-* RAILS_ENV=production bundle exec rake db:seed
-* RAILS_ENV=production bundle exec rake secrets
-* Add that value to `config/secrets.yml`
+* This section provides no advice on how to install and run blazegraph for production operations concerns.
+* Create a new blazegraph namespace, say `sparqlite`, using the defaults for a `triples` KB, and select 'use' it.
+* Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
+  * Browse to `db/nomisma-full.ttl` and select `Update`.
 
-Run the server in production mode pointing to the BlazeGraph SPARQL endpoint:
+Once the data is loaded into blazegraph, return to the sparqlite console to perform rails initialization:
 
-    SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite/sparql RAILS_ENV=production bundle exec rails server
+```
+bundle install
+RAILS_ENV=production bundle exec rake db:migrate
+RAILS_ENV=production bundle exec rake db:seed # this is done manually above
+RAILS_ENV=production bundle exec rake secrets
+# Add that value to `config/secrets.yml`
+```
 
-### Blazegraph for tests
+Run the server in production mode pointing to this BlazeGraph SPARQL endpoint:
+
+```
+export SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite/sparql
+RAILS_ENV=production bundle exec rails server
+```
+
+#### Development (demonstrations)
+
+* Exploring the application is much faster using blazegraph
+* Create a new blazegraph namespace, say `sparqlite-development`, using the defaults for a `triples` KB, and select 'use' it.
+* Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
+  * Browse to `db/nomisma_full.ttl` and select `Update`.  Once the data is loaded into blazegraph, return to the sparqlite console to prepare and run specs:
+
+```
+export SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite-development/sparql
+# RAILS_ENV=development is the default
+bundle exec rails s
+```
+
+#### Tests
 
 * Create a new blazegraph namespace, say `sparqlite-test`, using the defaults for a `triples` KB, and select 'use' it.
 * Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
@@ -115,16 +128,4 @@ RAILS_ENV=test bundle exec rake
 
 # To view the test data in the application:
 RAILS_ENV=development bundle exec rails s
-```
-
-### Blazegraph for development (demonstrations)
-
-* Exploring the application is much faster using blazegraph
-* Create a new blazegraph namespace, say `sparqlite-development`, using the defaults for a `triples` KB, and select 'use' it.
-* Load data using the blazegraph UI at http://localhost:9999/blazegraph/#update
-  * Browse to `db/nomisma_full.ttl` and select `Update`.  Once the data is loaded into blazegraph, return to the sparqlite console to prepare and run specs:
-
-```
-export SPARQL_URL=http://localhost:9999/blazegraph/namespace/sparqlite-development/sparql
-bundle exec rails s
 ```

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,15 +1,20 @@
 # SPARQL::Client configuration.
 # Production references the SPARQL endpoint. Development and test use the local SQLite3 service initialized with test data
 
-development:
+default: &default
   adapter: Sparql
   url: <%= ENV['SPARQL_URL'] %>
+
+development:
+  <<: *default
   repository: "mongo"
   collection: "nomisma_full"
+
 test: &test
-  adapter: Sparql
+  <<: *default
   repository: "mongo"
   collection: "nomisma"
+
 production:
-  adapter: Sparql
-  url: <%= ENV['SPARQL_URL'] || "http://127.0.0.1/FIXME" %>
+  <<: *default
+


### PR DESCRIPTION

Additions to the rails 5 update.  These enable using a SPARQL_URI in test and development and document the use of blazegraph for that purpose.